### PR TITLE
introduce distinction between 'rnode' and 'brdnode'

### DIFF
--- a/seedemu/compiler/Docker.py
+++ b/seedemu/compiler/Docker.py
@@ -761,6 +761,7 @@ class Docker(Compiler):
         if role == NodeRole.Host: return 'h'
         if role == NodeRole.Router: return 'r'
         if role == NodeRole.RouteServer: return 'rs'
+        if role == NodeRole.BorderRouter: return 'brd'
         assert False, 'unknown node role {}'.format(role)
 
     def _contextToPrefix(self, scope: str, type: str) -> str:

--- a/seedemu/core/AddressAssignmentConstraint.py
+++ b/seedemu/core/AddressAssignmentConstraint.py
@@ -165,8 +165,10 @@ class AddressAssignmentConstraint(Printable):
         @throws ValueError if try to get assigner of IX interface.
         """
 
-        if type == NodeRole.Host: return Assigner(self.__hostStart, self.__hostEnd, self.__hostStep)
-        if type == NodeRole.Router: return Assigner(self.__routerStart, self.__routerEnd, self.__routerStep)
+        if NodeRole.Host == type:
+            return Assigner(self.__hostStart, self.__hostEnd, self.__hostStep)
+        if NodeRole.Router == type or type == NodeRole.BorderRouter:
+            return Assigner(self.__routerStart, self.__routerEnd, self.__routerStep)
 
         raise ValueError("IX IP assignment must done with mapIxAddress().")
 

--- a/seedemu/core/Network.py
+++ b/seedemu/core/Network.py
@@ -56,9 +56,11 @@ class Network(Printable, Registrable, Vertex):
 
         self.__connected_nodes = []
 
-        self.__assigners[NodeRole.Router] = self.__aac.getOffsetAssigner(NodeRole.Router)
-        self.__assigners[NodeRole.Host] = self.__aac.getOffsetAssigner(NodeRole.Host)
-
+        ahost =  self.__aac.getOffsetAssigner(NodeRole.Host)
+        arouter = self.__aac.getOffsetAssigner(NodeRole.Router)
+        self.__assigners[ NodeRole.BorderRouter ] = arouter
+        self.__assigners[ NodeRole.Router ] = arouter
+        self.__assigners[ NodeRole.Host ] = ahost
         self.__d_latency = 0
         self.__d_bandwidth = 0
         self.__d_drop = 0

--- a/seedemu/core/ScionAutonomousSystem.py
+++ b/seedemu/core/ScionAutonomousSystem.py
@@ -185,8 +185,8 @@ class ScionAutonomousSystem(AutonomousSystem):
 
         # Border routers
         border_routers = {}
-        for router in self.getRouters():
-            rnode: ScionRouter = self.getRouter(router)
+        for router in self.getBorderRouters():
+            rnode: ScionRouter = self.getRouter( router.getName() )
 
             border_routers[rnode.getName()] = {
                 "internal_addr": f"{rnode.getLoopbackAddress()}:30001",

--- a/seedemu/core/enums.py
+++ b/seedemu/core/enums.py
@@ -29,5 +29,7 @@ class NodeRole(Enum):
     ## Router node.
     Router = "Router"
 
+    BorderRouter = "BorderRouter"
+
     ## Route served node.
     RouteServer = "Route Server"

--- a/seedemu/layers/Ebgp.py
+++ b/seedemu/layers/Ebgp.py
@@ -335,7 +335,7 @@ class Ebgp(Layer, Graphable):
             assert len(rs_ifs) == 1, '??? ix{} rs has {} interfaces.'.format(ix, len(rs_ifs))
             rs_if = rs_ifs[0]
 
-            p_rnodes: List[Router] = p_reg.getByType('rnode')
+            p_rnodes: List[Router] = p_reg.getByType('brdnode')
             p_ixnode: Router = None
             p_ixif: Interface = None
             for node in p_rnodes:
@@ -363,15 +363,15 @@ class Ebgp(Layer, Graphable):
 
             hit = False
 
-            for node in a_reg.getByType('rnode'):
+            for node in a_reg.getByType('brdnode'):
                 router: Router = node
                 for (peername, peerasn), (localaddr, _) in router.getCrossConnects().items():
                     if peerasn != b: continue
-                    if not b_reg.has('rnode', peername): continue
+                    if not b_reg.has('brdnode', peername): continue
 
                     hit = True
                     a_router = node
-                    b_router = b_reg.get('rnode', peername)
+                    b_router = b_reg.get('brdnode', peername)
 
                     a_addr = str(localaddr.ip)
                     (b_ifaddr, _) = b_router.getCrossConnect(a, a_router.getName())

--- a/seedemu/layers/Ibgp.py
+++ b/seedemu/layers/Ibgp.py
@@ -56,8 +56,8 @@ class Ibgp(Layer, Graphable):
             neighs: List[Node] = net.getAssociations()
 
             for neigh in neighs:
-
-                if neigh.getRole() != NodeRole.Router: 
+                role = neigh.getRole()
+                if role != NodeRole.Router and role != NodeRole.BorderRouter: 
                     continue
                 
                 self.__dfs(neigh, visited, net.getName())

--- a/seedemu/layers/Routing.py
+++ b/seedemu/layers/Routing.py
@@ -97,7 +97,9 @@ class Routing(Layer):
 
                 rs_iface = rs_ifaces[0]
 
-                if not issubclass(rs_node.__class__, Router): rs_node.__class__ = Router
+                if not issubclass(rs_node.__class__, Router):
+                    rs_node.__class__ = Router
+                    rs_node.setBorderRouter(True)
                 rs_node.setFile("/etc/bird/bird.conf", RoutingFileTemplates["rs_bird"].format(
                     routerId = rs_iface.getAddress()
                 ))

--- a/seedemu/layers/Scion.py
+++ b/seedemu/layers/Scion.py
@@ -303,10 +303,10 @@ class Scion(Layer, Graphable):
     @staticmethod
     def __get_xc_routers(a: int, a_reg: ScopedRegistry, b: int, b_reg: ScopedRegistry) -> Tuple[Router, Router]:
         """Find routers responsible for a cross-connect link between a and b."""
-        for router in a_reg.getByType('rnode'):
+        for router in a_reg.getByType('brdnode'):
             for peer, asn in router.getCrossConnects().keys():
-                if asn == b and b_reg.has('rnode', peer):
-                    return (router, b_reg.get('rnode', peer))
+                if asn == b and b_reg.has('brdnode', peer):
+                    return (router, b_reg.get('brdnode', peer))
         assert False
 
     @staticmethod

--- a/seedemu/layers/ScionRouting.py
+++ b/seedemu/layers/ScionRouting.py
@@ -81,7 +81,8 @@ class ScionRouting(Routing):
 
         reg = emulator.getRegistry()
         for ((scope, type, name), obj) in reg.getAll().items():
-            if type == 'rnode':
+            # SCION inter-domain routing affects only border-routers
+            if type == 'brdnode':
                 rnode: ScionRouter = obj
                 if not issubclass(rnode.__class__, ScionRouter):
                     rnode.__class__ = ScionRouter
@@ -133,7 +134,7 @@ class ScionRouting(Routing):
 
         reg = emulator.getRegistry()
         for ((scope, type, name), obj) in reg.getAll().items():
-            if type in ['rnode', 'csnode', 'hnode']:
+            if type in ['brdnode', 'csnode', 'hnode']:
                 node: Node = obj
                 asn = obj.getAsn()                
                 as_: ScionAutonomousSystem = base_layer.getAutonomousSystem(asn)
@@ -146,7 +147,7 @@ class ScionRouting(Routing):
 
                 self.__provision_base_config(node)
 
-            if type == 'rnode':
+            if type == 'brdnode':
                 rnode: ScionRouter = obj
                 self.__provision_router_config(rnode)                
             elif type == 'csnode':


### PR DESCRIPTION
not all routers within an AS are border routers, and hence need not all the software installed.
This PR adds clear differentiation between the two by introducing a separate NodeRole.
The initial discussion was held here: https://github.com/seed-labs/seed-emulator/pull/181#issuecomment-1981822604
The removal of the obsolete software is not included in this PR because it will interfere with the 'ScionBuildConfiguration'.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsys-lab/seed-emulator/16)
<!-- Reviewable:end -->
