### PR TITLE
support named docker volumes

### DIFF
--- a/seedemu/compiler/DistributedDocker.py
+++ b/seedemu/compiler/DistributedDocker.py
@@ -1,11 +1,12 @@
 # Distributed Docker Compiler is not maintained 
 
 from .Docker import Docker, DockerCompilerFileTemplates
-from seedemu.core import Emulator, ScopedRegistry, Node, Network
+from seedemu.core import Emulator, ScopedRegistry, Node, Network, BaseVolume
 from seedemu.core.enums import NodeRole
 from typing import Dict
 from hashlib import md5
 from os import mkdir, chdir, rmdir
+from yaml import dump
 
 DistributedDockerCompilerFileTemplates: Dict[str, str] = {}
 
@@ -70,6 +71,28 @@ class DistributedDocker(Docker):
 
     def _doCompile(self, emulator: Emulator):
         registry = emulator.getRegistry()
+
+        self._groupSoftware(emulator)
+
+        toplevelvolumes = '' 
+        if len(topvols := self._getVolumes()) > 0:
+            toplevelvolumes += 'volumes:\n'
+            #topvols = set(map( lambda vol: TopLvlVolume(vol), pool.getVolumes() ))
+
+            for v in  topvols:
+                v.mode = 'toplevel'
+
+            #toplevelvolumes += '\n'.join(map( lambda line: '        ' + line ,dump( topvols ).split('\n') ) ) 
+
+            # sharedFolders/bind mounts do not belong in the top-level volumes section
+            for v in [vv  for  vv in topvols if vv.asDict()['type'] == 'volume' ]: 
+                toplevelvolumes += '  {}:\n'.format(v.asDict()['source']) # why not 'name'
+                lines = dump( v ).rstrip('\n').split('\n')
+                toplevelvolumes += '\n'.join( map( lambda x: '        ' if x[0] != 0 
+                                                else '        ' + x[1] if x[1] != ''
+                                                else '', enumerate(lines ) ) )
+                toplevelvolumes += '\n'
+
         scopes = set()
         for (scope, _, _) in registry.getAll().keys(): scopes.add(scope)
 
@@ -114,6 +137,7 @@ class DistributedDocker(Docker):
                 print(DockerCompilerFileTemplates['compose'].format(
                     services = services,
                     networks = networks,
+                    volumes = toplevelvolumes,
                     dummies = self._makeDummies()
                 ), file=open('docker-compose.yml', 'w'))
 

--- a/seedemu/compiler/Docker.py
+++ b/seedemu/compiler/Docker.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from seedemu.core.Emulator import Emulator
-from seedemu.core import Node, Network, Compiler, BaseSystem, BaseOption, Scope, ScopeType, ScopeTier, OptionHandling
+from seedemu.core import Node, Network, Compiler, BaseSystem, BaseOption, Scope, ScopeType, ScopeTier, OptionHandling, BaseVolume
 from seedemu.core.enums import NodeRole, NetworkType
 from .DockerImage import DockerImage
 from .DockerImageConstant import *
@@ -12,7 +12,7 @@ from re import sub
 from ipaddress import IPv4Network, IPv4Address
 from shutil import copyfile
 import json
-
+from yaml import dump
 
 SEEDEMU_INTERNET_MAP_IMAGE='handsonsecurity/seedemu-multiarch-map:buildx-latest'
 SEEDEMU_ETHER_VIEW_IMAGE='handsonsecurity/seedemu-multiarch-etherview:buildx-latest'
@@ -104,6 +104,7 @@ services:
 {services}
 networks:
 {networks}
+{volumes}
 """
 
 DockerCompilerFileTemplates['compose_dummy'] = """\
@@ -157,16 +158,6 @@ DockerCompilerFileTemplates['compose_port'] = """\
 DockerCompilerFileTemplates['compose_volumes'] = """\
         volumes:
 {volumeList}
-"""
-
-DockerCompilerFileTemplates['compose_volume'] = """\
-            - type: bind
-              source: {hostPath}
-              target: {nodePath}
-"""
-
-DockerCompilerFileTemplates['compose_storage'] = """\
-            - {nodePath}
 """
 
 DockerCompilerFileTemplates['compose_service_network'] = """\
@@ -394,6 +385,13 @@ class Docker(Compiler):
         self._used_images = set()
         self.__image_per_node_list = {}
         self.__config = [] # variables for '.env' file alongside 'docker-compose.yml'
+
+        self.__volumes_dedup = (
+            []
+        )  # unforunately set(()) failed to automatically deduplicate
+        self.__vol_names = []
+        super().__init__()
+
         self.__platform = platform
 
         self.__basesystem_dockerimage_mapping = BASESYSTEM_DOCKERIMAGE_MAPPING_PER_PLATFORM[self.__platform]
@@ -403,10 +401,28 @@ class Docker(Compiler):
             if name == BaseSystem.DEFAULT:
                 priority = 1
             self.addImage(image, priority=priority)
+    
+    def _addVolume(self, vol: BaseVolume):
+        """! @brief add a docker volume/bind mount/or tmpfs
 
+        Remember them for later, to generate the top lvl 'volumes:' section of docker-compose.yml
+        """
+        # if vol.type() == 'volume': # then it is a named-volume
+        key = vol.asDict()["source"]
+        if key not in self.__vol_names:
+            self.__volumes_dedup.append(vol)
+            self.__vol_names.append(key)
+        return self
+
+    def _getVolumes(self) -> List[BaseVolume]:
+        """! @brief get all docker volumes/mounts that must appear 
+            in docker-compose.yml top-level  'volumes:' section
+        """
+        return self.__volumes_dedup
+    
     def optionHandlingCapabilities(self) -> OptionHandling:
         return OptionHandling.DIRECT_DOCKER_COMPOSE | OptionHandling.CREATE_SEPARATE_ENV_FILE
-
+    
     def getName(self) -> str:
         return "Docker"
 
@@ -906,28 +922,23 @@ class Docker(Compiler):
         return node_nets, dummy_addr_map
 
     def _getComposeNodeVolumes(self, node: Node) -> str:
-        _volumes = node.getSharedFolders()
-        storages = node.getPersistentStorages()
+        """ compute the docker-compose 'volumes:' section for this service"""
 
         volumes = ''
+        # svcvols = map( lambda vol: ServiceLvlVolume(vol), node.getCustomVolumes() )
+        svcvols = list (set(node.getDockerVolumes() ))
+        for v in svcvols:
+            v.mode = 'service'
+        yamlvols = '\n'.join(map( lambda line: '        ' + line ,dump( svcvols ).split('\n') ) ) 
+       
+        volumes +='        volumes:\n' + yamlvols if len(node.getDockerVolumes()) > 0 else   ''
 
-        if len(_volumes) > 0 or len(storages) > 0:
-            lst = ''
+        
+        # the top-level docker-compose volumes section is rendered at a later stage ..
+        # Remember encountered volumes until then
+        for v in node.getDockerVolumes():
+            self._addVolume(v)
 
-            for (nodePath, hostPath) in _volumes.items():
-                lst += DockerCompilerFileTemplates['compose_volume'].format(
-                    hostPath = hostPath,
-                    nodePath = nodePath
-                )
-
-            for path in storages:
-                lst += DockerCompilerFileTemplates['compose_storage'].format(
-                    nodePath = path
-                )
-
-            volumes = DockerCompilerFileTemplates['compose_volumes'].format(
-                volumeList = lst
-            )
         return volumes
 
     def _computeDockerfile(self, node: Node) -> str:
@@ -1259,10 +1270,29 @@ class Docker(Compiler):
                 dirName = image.getDirName()
             )
 
+        toplevelvolumes = '' 
+        if len(topvols := self._getVolumes()) > 0:
+            toplevelvolumes += 'volumes:\n'
+            #topvols = set(map( lambda vol: TopLvlVolume(vol), pool.getVolumes() ))
+
+            for v in  topvols:
+                v.mode = 'toplevel'
+
+            #toplevelvolumes += '\n'.join(map( lambda line: '        ' + line ,dump( topvols ).split('\n') ) ) 
+
+            # sharedFolders/bind mounts do not belong in the top-level volumes section
+            for v in [vv  for  vv in topvols if vv.asDict()['type'] == 'volume' ]: 
+                toplevelvolumes += '  {}:\n'.format(v.asDict()['source']) # why not 'name'
+                lines = dump( v ).rstrip('\n').split('\n')
+                toplevelvolumes += '\n'.join( map( lambda x: '        ' if x[0] != 0 else '        ' + x[1] if x[1] != ''else '' , enumerate(lines ) ) )
+                toplevelvolumes += '\n'
+
+
         self._log('creating docker-compose.yml...'.format(scope, name))
         print(DockerCompilerFileTemplates['compose'].format(
             services = self.__services,
             networks = self.__networks,
+            volumes = toplevelvolumes,
             dummies = local_images + self._makeDummies()
         ), file=open('docker-compose.yml', 'w'))
 

--- a/seedemu/core/Node.py
+++ b/seedemu/core/Node.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import random
+import string
 from .Printable import Printable
 from .Network import Network
 from .enums import NodeRole
@@ -6,6 +8,7 @@ from .Scope import *
 from .Registry import Registrable
 from .Emulator import Emulator
 from .Customizable import Customizable
+from .Volume import BaseVolume
 from .Configurable import Configurable
 from .enums import NetworkType
 from .Visualization import Vertex
@@ -230,8 +233,7 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
     # Dict of (peername, peerasn) -> (localaddr, netname, netProperties) -- netProperties = (latency, bandwidth, packetDrop, MTU)
     __xcs: Dict[Tuple[str, int], Tuple[IPv4Interface, str, Tuple[int,int,float,int]]]
 
-    __shared_folders: Dict[str, str]
-    __persistent_storages: List[str]
+    __custom_vols: List[BaseVolume]
     __name_servers: List[str]
 
     __geo: Tuple[float,float,str] # (Latitude,Longitude,Address) -- optional parameter that contains the geographical location of the Node
@@ -270,8 +272,7 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
         self.__xcs = {}
         self.__configured = False
 
-        self.__shared_folders = {}
-        self.__persistent_storages = []
+        self.__custom_vols = []
 
         for soft in DEFAULT_SOFTWARE:
             self.__softwares.add(soft)
@@ -383,6 +384,15 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
         self.__name_servers = servers
 
         return self
+        
+    def addDockerVolume(self, vol: BaseVolume ):
+        """adds the docker volume to this node's container"""
+        self.__custom_vols.append(vol )
+        return self
+    
+    def getDockerVolumes(self):
+        """!@brief retrieve any volumes mounted on this node's container"""
+        return self.__custom_vols
 
     # TODO: if a separate .env file is created, or the values are given directly in the docker-compose.yml 'environment' section
     # could be a setting of the Docker compiler
@@ -891,29 +901,22 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
         """
         return self.__interfaces
 
-    def addSharedFolder(self, nodePath: str, hostPath: str) -> Node:
+    def addSharedFolder(self, nodePath: str, hostPath: str, **kwargs) -> Node:
         """!
         @@brief Add a new shared folder between the node and host.
 
         @param nodePath path to the folder inside the container.
         @param hostPath path to the folder on the emulator host node.
+        @param kwargs any other docker volume options i.e. 'readonly'
 
         @returns self, for chaining API calls.
         """
-        self.__shared_folders[nodePath] = hostPath
+        # bind mounts are never named!
+        self.__custom_vols.append(  BaseVolume(source=hostPath, target=nodePath, type='bind', **kwargs) )
 
         return self
 
-    def getSharedFolders(self) -> Dict[str, str]:
-        """!
-        @brief Get shared folders between the node and host.
-
-        @returns dict, where key is the path in container and value is path on
-        host.
-        """
-        return self.__shared_folders
-
-    def addPersistentStorage(self, path: str) -> Node:
+    def addPersistentStorage(self, path: str, name: str=None, **kwargs) -> Node:
         """!
         @brief Add persistent storage to node.
 
@@ -921,20 +924,20 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
         directory where data will be persistent.
 
         @param path path to put the persistent storage folder in the container.
+        @param name if specified a named-volume is created.
+            By specifying the same name on multiple nodes
+            the volume is effectively shared between those containers.
+        @param kwargs any other docker volume options i.e. 'readonly'
 
         @returns self, for chaining API calls.
         """
-        self.__persistent_storages.append(path)
+        
+        if name == None: # generate random name for anonymus volume
+            name = ''.join(random.choice(string.ascii_lowercase) for i in range(6))
+
+        self.__custom_vols.append(  BaseVolume(target=path, type='volume', name=name, source=name, **kwargs) )
 
         return self
-
-    def getPersistentStorages(self) -> List[str]:
-        """!
-        @brief Get persistent storage folders on the node.
-
-        @returns list of persistent storage folder.
-        """
-        return self.__persistent_storages
 
     def setGeo(self, Lat: float, Long: float, Address: str="") -> Node:
         """!
@@ -995,7 +998,7 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
         # if node.getBaseSystem() != None : self.setBaseSystem(node.getClasses())
 
         for (h, n, p) in node.getPorts(): self.addPort(h, n, p)
-        for p in node.getPersistentStorages(): self.addPersistentStorage(p)
+        for v in node.getDockerVolumes(): self.addDockerVolume(v)
         for (c, f) in node.getStartCommands(): self.appendStartCommand(c, f)
         # for (c, f) in node.getUserStartCommands(): self.appendUserStartCommand(c, f)
         for c in node.getBuildCommands(): self.addBuildCommand(c)

--- a/seedemu/core/Volume.py
+++ b/seedemu/core/Volume.py
@@ -1,0 +1,214 @@
+from .Registry import Registrable
+from yaml import *
+from typing import Dict, Tuple, List, Set
+
+# use collections defaultdict ?!
+class ddict(dict):
+
+    def __getitem__(self, item):
+        try:
+            return dict.__getitem__(self, item)
+        except KeyError:
+            value = self[item] = type(self)()
+            return value
+    
+    def clean_dict(self):
+        return {k: v for k, v in self.items() if v not in [None, [], {}]}
+
+
+class YAMLMultiObjectMetaclass(YAMLObjectMetaclass):
+    """
+    The metaclass for YAMLMultiObject.
+    """
+
+    def __init__(cls, name, bases, kwds):
+        super(YAMLMultiObjectMetaclass, cls).__init__(name, bases, kwds)
+        if "yaml_tag" in kwds and kwds["yaml_tag"] is not None:
+            # cls.yaml_loader.add_multi_constructor(cls.yaml_tag, cls.from_yaml)
+            cls.yaml_dumper.add_multi_representer(cls, cls.to_yaml)
+
+
+class YAMLMultiObject(YAMLObject, metaclass=YAMLMultiObjectMetaclass):
+    """
+    An object that dumps itself to a stream.
+
+    Use this class instead of YAMLObject in case 'to_yaml' and 'from_yaml' should
+    be inherited by subclasses.
+    """
+
+    pass
+
+
+class BaseVolume(YAMLMultiObject):
+    """
+    @brief representation of a docker-compose volume
+
+    It can have one of the following types:
+    - 'bind' for shared folders (bind-mounts)
+    - 'volume' for anonymus or named docker volumes
+        (depending on wether 'name' is set)
+    - tmpfs
+    """
+
+    yaml_tag = "!BaseVolume"
+
+    def __init__(self, **kwargs):
+        self._data = ddict()
+        self.mode = "base"
+
+        # services level volume elements
+        self._data["type"] = "volume"
+        self._data["source"] = None
+        self._data["target"] = None
+
+        # bind: {propagation:  , selinux: , create_host_path: }
+        self._data["read_only"] = False
+        # volume: {nocopy: bool }
+
+        # Volumes top-level elements
+        self._data["driver"] = None  # str
+        self._data["name"] = None  # str
+        self._data["labels"] = []
+        self._data["driver_opts"] = ddict()
+        self._data["external"] = (
+            None  # might be bool or {name: external-name-to-lookup}
+        )
+
+        self._data["subdir"] = None
+
+        for key, value in kwargs.items():
+            # only handle valid keys, docker knows about
+            if key in self._data:
+                if key == "labels":
+                    self._data[key].append(value)
+                else:
+                    self._data[key] = value
+
+        super().__init__()
+
+    def __hash__(self):
+        return hash((self._data["type"], self._data["target"], self._data["source"]))
+
+    def __eq__(self, other):
+        return (self._data["type"], self._data["source"], self._data["target"]) == (
+            other.asDict()["type"],
+            other.asDict()["source"],
+            other.asDict()["target"],
+        )
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return basevol_representer(dumper, data)
+
+    def __repr__(self) -> str:
+        vals = []
+        if self._data["type"] != None:
+            vals.append("type={}".format(self._data["type"]))
+        if self._data["source"] != None:
+            vals.append("source={}".format(self._data["source"]))
+        if self._data["target"] != None:
+            vals.append("target={}".format(self._data["target"]))
+
+        return "Volume(%r)" % (", ".join(vals))
+
+    def asDict(self):
+        return self._data
+
+    def getType(self) -> str:
+        """!@brief  returns the type of the volume
+        one of
+            - sharedFolder -> bind
+            - named or anonymous volume -> volume
+            - tmpfs
+        """
+        return self._data["type"]
+
+    def setType(self, _type: str):
+        """
+        one of 'volume' , 'bind', 'tmpfs'
+        """
+        assert _type in ['volume' , 'bind', 'tmpfs'], f'unknown docker volume type: {_type}'
+        self._data["type"] = _type
+        return self
+
+    def setSource(self, src: str):
+
+        self._data["source"] = src
+        return self
+
+
+# prints all attributes
+def basevol_representer(dumper, data: BaseVolume):
+    if data.mode == "base":
+        return dumper.represent_dict(            
+                data.asDict().clean_dict()          
+        )
+    elif data.mode == "service":
+        return dumper.represent_dict(
+            filter(
+                lambda kv: kv[0] in ["type", "source", "target", "read_only"],
+                data.asDict().clean_dict().items(),
+            )
+        )
+    elif data.mode == "toplevel":
+        return dumper.represent_dict(
+            filter(
+                lambda kv: kv[0] in ["driver", "name", "labels", "external", "driver_opts"],
+                data.asDict().clean_dict().items(),
+            )
+        )
+
+
+add_representer(BaseVolume, basevol_representer)
+
+
+class ServiceLvlVolume(BaseVolume):
+    # def __init__(**kwargs):
+    #    super().__init__(kwargs)
+    yaml_tag = "!SvcVolume"
+
+    def __init__(self, obj):
+        super().__init__()
+        self._data = obj._data
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return svcvol_representer(dumper, data)
+
+
+def svcvol_representer(dumper, data: BaseVolume):
+    return dumper.represent_dict(
+        filter(
+            lambda kv: kv[0] in ["type", "source", "target"],
+            data.asDict().clean_dict().items(),
+        )
+    )
+
+
+add_representer(ServiceLvlVolume, svcvol_representer)
+
+
+class TopLvlVolume(BaseVolume):
+    # def __init__(self,**kwargs):
+    #    super().__init__(kwargs)
+    yaml_tag = "!Volume"
+
+    def __init__(self, obj):
+        super().__init__()
+        self._data = obj._data
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return topvol_representer(dumper, data)
+
+
+def topvol_representer(dumper, data):
+    return dumper.represent_dict(
+        filter(
+            lambda kv:  kv[0] in ["driver", "name", "labels", "external", "driver_opts"],
+            data.asDict().clean_dict().items(),
+        )
+    )
+
+
+add_representer(TopLvlVolume, topvol_representer)

--- a/seedemu/core/__init__.py
+++ b/seedemu/core/__init__.py
@@ -23,3 +23,4 @@ from .Compiler import Compiler, OptionHandling
 from .BaseSystem import BaseSystem
 from .Scope import *
 from .Option import BaseOption, OptionMode
+from .Volume import BaseVolume, ServiceLvlVolume, TopLvlVolume


### PR DESCRIPTION
introduce the notion of docker volumes into seed codebase.
Thus unify the handling of 'persistentStorage' and 'sharedFolders'.
By adding a second 'name' parameter to 'addPersistentStorage()' nodes can now create named rather than anonymous volumes and even share them.